### PR TITLE
fix: remove non-functional preset/Eco controls on T0x44 thermostat

### DIFF
--- a/custom_components/midea_auto_cloud/device_mapping/T0x44.py
+++ b/custom_components/midea_auto_cloud/device_mapping/T0x44.py
@@ -23,14 +23,6 @@ DEVICE_MAPPING = {
                         "heat": {"power": "on", "mode": 4},
                         "fan_only": {"power": "on", "mode": 5},
                     },
-                    "preset_modes": {
-                        "none": {
-                            "eco": "off",
-                            "strong_wind": "off",
-                        },
-                        "eco": {"eco": "on"},
-                        "boost": {"strong_wind": "on"},
-                    },
                     # "swing_modes": {
                     #     "off": {"horizontal_swing_wind": 0, "vertical_swing_wind": 0},
                     #     "both": {"horizontal_swing_wind": 1, "vertical_swing_wind": 1},
@@ -100,7 +92,6 @@ DEVICE_MAPPING = {
                 },
             },
             Platform.SWITCH: {
-                "eco": {"device_class": SwitchDeviceClass.SWITCH},
                 "ptc": {"device_class": SwitchDeviceClass.SWITCH},
                 "digital_display": {"device_class": SwitchDeviceClass.SWITCH},
                 "voice_control": {"device_class": SwitchDeviceClass.SWITCH},


### PR DESCRIPTION
**Summary** — Removes the preset selector (none/eco/boost) and the standalone "Eco" switch from the T0x44 thermostat, because they don't do anything on this device.

**Why** — These controls map to the `eco` / `strong_wind` device attributes, but on a T0x44 (M-Station MTL04-1 on an evoX G3) the device doesn't act on them: the Midea cloud API rejects the values and the selection reverts after the next status update. Neither the physical thermostat nor the MSmartHome app exposes these options for this device, so the controls are misleading.

**Change** — Remove the climate `preset_modes` block and the `eco` switch from the T0x44 mapping. No `climate.py` change is needed: the preset feature is only advertised when a mapping defines `preset_modes`, so dropping it cleanly removes the control. Mapping-only and scoped to T0x44 — no other device type is affected.

**Testing** — Verified on a T0x44 / M-Station MTL04-1 thermostat with Evox G3 HVAC system: the preset chips and the Eco switch no longer appear; other controls unaffected.

Fixes #201

(Implemented by Claude Code Opus 4.8, tested on my T0x44 / M-Station MTL04-1 Evox G3 HVAC systems)
