### PR TITLE
fix: hide fan-mode control on T0x44 while hvac mode is auto

### DIFF
--- a/custom_components/midea_auto_cloud/climate.py
+++ b/custom_components/midea_auto_cloud/climate.py
@@ -76,6 +76,9 @@ class MideaClimateEntity(MideaEntity, ClimateEntity):
         self._key_aux_heat = self._config.get("aux_heat")
         self._key_swing_modes = self._config.get("swing_modes")
         self._key_fan_modes = self._config.get("fan_modes")
+        # Hvac modes in which the device locks fan speed (it manages airflow
+        # itself); the fan-mode control is hidden while in one of these modes.
+        self._fan_lock_hvac_modes = self._config.get("fan_lock_hvac_modes") or []
         self._key_min_temp = self._config.get("min_temp")
         self._key_max_temp = self._config.get("max_temp")
         self._key_current_temperature = self._config.get("current_temperature")
@@ -144,6 +147,10 @@ class MideaClimateEntity(MideaEntity, ClimateEntity):
             and self.hvac_mode in self._range_hvac_modes
         )
 
+    def _fan_mode_locked(self) -> bool:
+        """True when the current hvac mode locks fan speed (device-managed)."""
+        return self.hvac_mode in self._fan_lock_hvac_modes
+
     @property
     def supported_features(self):
         features = ClimateEntityFeature(0)
@@ -161,7 +168,7 @@ class MideaClimateEntity(MideaEntity, ClimateEntity):
             features |= ClimateEntityFeature.AUX_HEAT
         if self._key_swing_modes is not None:
             features |= ClimateEntityFeature.SWING_MODE
-        if self._key_fan_modes is not None:
+        if self._key_fan_modes is not None and not self._fan_mode_locked():
             features |= ClimateEntityFeature.FAN_MODE
         return features
 
@@ -606,6 +613,10 @@ class MideaClimateEntity(MideaEntity, ClimateEntity):
         await self.async_set_attributes(new_status)
 
     async def async_set_fan_mode(self, fan_mode: str):
+        if self._fan_mode_locked():
+            # Fan speed is device-managed in these hvac modes (e.g. auto); the
+            # control is hidden, so ignore stray service calls rather than write.
+            return
         fan_mode = normalize_fan_mode_input(self._key_fan_modes, fan_mode)
         fan_modes = fan_mode_lookup_mapping(self._key_fan_modes)
         if self._is_central_ac:

--- a/custom_components/midea_auto_cloud/device_mapping/T0x44.py
+++ b/custom_components/midea_auto_cloud/device_mapping/T0x44.py
@@ -43,6 +43,10 @@ DEVICE_MAPPING = {
                         "high": {"wind_speed": 90},
                         "auto": {"wind_speed": 102},
                     },
+                    # The thermostat/app lock fan speed while the hvac mode is
+                    # auto (the unit manages airflow itself), so hide the
+                    # fan-mode control on the climate card in that mode.
+                    "fan_lock_hvac_modes": ["auto"],
                     "target_temperature": "temperature",
                     # In auto mode the thermostat controls to a low/high range
                     # (the control_function limits, same as the number entities),


### PR DESCRIPTION
**Summary** — Hides the climate fan-mode control on the T0x44 thermostat while the hvac mode is auto, matching the device's own behavior.

**Why** — On a T0x44 (M-Station MTL04-1 on an evoX G3) the fan speed can't be changed while heat/cool is in auto — the unit manages airflow itself, and both the physical thermostat and the MSmartHome app lock the fan control in that mode. Home Assistant still showed a selectable auto/low/med/high dropdown, and selecting a speed had no effect.

**Change** — Adds an optional, mapping-driven `fan_lock_hvac_modes` key. When the current hvac mode is listed, the entity drops `ClimateEntityFeature.FAN_MODE` (hiding the control) and `async_set_fan_mode` becomes a no-op. Defaults to an empty list, so behavior is unchanged for every other device/mapping. Enabled for the T0x44 with `"fan_lock_hvac_modes": ["auto"]`.

**Testing** — Verified on a T0x44 / M-Station MTL04-1 thermostat with Evox G3 HVAC system: in auto the fan-mode control is hidden; switching to cool/heat/dry/fan-only shows it again and it works as before.

Fixes #202

(Implemented by Claude Code Opus 4.8, tested on my T0x44 / M-Station MTL04-1 Evox G3 HVAC systems)
