### PR TITLE
feat: dedicated T0xAC profile for the portable split family (subtype 524)

### DIFF
--- a/custom_components/midea_auto_cloud/device_mapping/T0xAC.py
+++ b/custom_components/midea_auto_cloud/device_mapping/T0xAC.py
@@ -147,6 +147,104 @@ DEVICE_MAPPING = {
             }
         }
     },
+    # Midea portable split family (subtype/modelNumber 524, smartProductId 10006481 -
+    # the latter names the protocol lua T_0000_AC_10006481_*.lua). The sn8 on these units
+    # is the shared placeholder "00000Q1F" (the same code appears on unrelated device
+    # types, e.g. a dehumidifier in midea_ac_lan#664), so subtype is the only reliable
+    # key. Differences from "default", all verified on hardware 2026-07-16:
+    #   - min_temp 16: the unit accepts and holds 16 (set from the Midea app, mirrored
+    #     back, and cloud-controlled at 16 all day). The device protocol lua
+    #     (T_0000_AC_10006481_*.lua) validates 13..16 as an extended range with its own
+    #     encoding next to the normal 17..30 - the static 17 was the integration
+    #     clamping, not the hardware. 16 is the deepest the vendor app itself offers.
+    #   - whole-degree steps: the unit rounds half-degree targets.
+    #   - single vertical louvre: no left/right swing motor (wind_swing_lr does nothing).
+    #   - no fresh-air module, no body-presence sensor, no straight-wind vane, and the
+    #     humidity register reads a constant 0 -> those entities/queries are dropped.
+    ("subtype", 524): {
+        "rationale": ["off", "on"],
+        "queries": [{}, {"query_type": "run_status"},
+                    {"query_type": "indoor_temperature"}, {"query_type": "group_data_four"}],
+        "centralized": [],
+        "calculate": {
+            "get": [
+                {
+                    "lvalue": "[real_time_power_value]",
+                    "rvalue": "float([real_time_power]) / 10"
+                },
+            ],
+        },
+        "entities": {
+            Platform.CLIMATE: {
+                "thermostat": {
+                    "power": "power",
+                    "hvac_modes": {
+                        "off": {"power": "off"},
+                        "heat": {"power": "on", "mode": "heat"},
+                        "cool": {"power": "on", "mode": "cool"},
+                        "auto": {"power": "on", "mode": "auto"},
+                        "dry": {"power": "on", "mode": "dry"},
+                        "fan_only": {"power": "on", "mode": "fan"}
+                    },
+                    "preset_modes": {
+                        "none": {
+                            "eco": "off",
+                            "comfort_power_save": "off",
+                            "cool_power_saving": 0,
+                            "strong_wind": "off"
+                        },
+                        "eco": {"eco": "on", "cool_power_saving": 1},
+                        "comfort": {"comfort_power_save": "on"},
+                        "boost": {"strong_wind": "on"}
+                    },
+                    "swing_modes": {
+                        "off": {"wind_swing_lr": "off", "wind_swing_ud": "off"},
+                        "vertical": {"wind_swing_lr": "off", "wind_swing_ud": "on"},
+                    },
+                    "fan_modes": {
+                        "silent": {"wind_speed": 20},
+                        "low": {"wind_speed": 40},
+                        "medium": {"wind_speed": 60},
+                        "high": {"wind_speed": 80},
+                        "full": {"wind_speed": 100},
+                        "auto": {"wind_speed": 102}
+                    },
+                    "target_temperature": ["temperature", "small_temperature"],
+                    "current_temperature": "indoor_temperature",
+                    "pre_mode": "mode",
+                    "aux_heat": "ptc",
+                    "min_temp": 16,
+                    "max_temp": 30,
+                    "temperature_unit": UnitOfTemperature.CELSIUS,
+                    "precision": PRECISION_WHOLE,
+                }
+            },
+            Platform.SWITCH: {
+                "dry": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                },
+                "aux_heat": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                },
+            },
+            Platform.SENSOR: {
+                "mode": {
+                    "device_class": SensorDeviceClass.ENUM,
+                },
+                "indoor_temperature": {
+                    "device_class": SensorDeviceClass.TEMPERATURE,
+                    "unit_of_measurement": UnitOfTemperature.CELSIUS,
+                    "state_class": SensorStateClass.MEASUREMENT
+                },
+                "real_time_power_value": {
+                    "device_class": SensorDeviceClass.POWER,
+                    "unit_of_measurement": UnitOfPower.WATT,
+                    "state_class": SensorStateClass.MEASUREMENT,
+                    "translation_key": "real_time_power",
+                }
+            }
+        }
+    },
     # Issue #211：22012895 调温需带 power/mode，避免实体误显示 off
     "22012895": {
         "rationale": ["off", "on"],


### PR DESCRIPTION
## 摘要

为便携式分体空调（subtype/modelNumber **524**，smartProductId 10006481）新增 `("subtype", 524)` 设备映射。这类设备的 sn8 是共享占位符 `00000Q1F`，无法用 sn8 区分，因此按照 `T0x21`/`T0xC3` 已有的 tuple-key 约定使用 subtype 匹配。主要修复：设备实际支持 16°C 最低目标温度，而通用映射的静态 `min_temp: 17` 把它挡住了。

## Problem

Portable split units (subtype 524) fall through to the `default` T0xAC mapping, which advertises capabilities this family doesn't have (left/right swing, fresh-air module, presence sensor, an always-0 humidity register) and clamps `min_temp` at 17.

The clamp is the real pain point: the device's protocol lua (`T_0000_AC_10006481_*.lua`) validates an extended 13..16 range alongside the normal 17..30, and the vendor MSmartHome app itself offers 16 — so `climate.set_temperature(16)` failing with a validation error was the integration clamping, not the hardware. For a single-hose portable unit that struggles against hot rooms, that last degree of setpoint matters: the unit regulates off its own intake sensor and parks the compressor early, so a lower target keeps it pulling meaningfully longer.

These units can't be keyed by sn8: `00000Q1F` is a shared placeholder that appears on entirely unrelated device types (e.g. a dehumidifier in georgezhao2010/midea_ac_lan#664). Subtype is the only reliable key, and `__init__.py` already prioritizes `("subtype", ...)` tuple matches.

## Solution

One addition to `device_mapping/T0xAC.py`, following the existing tuple-key profiles:

- `min_temp: 16`, whole-degree precision (the unit rounds half-degree targets)
- swing limited to off/vertical (single louvre, no left/right motor)
- drops the fresh-air, presence, straight-wind and humidity entities the family lacks
- keeps the useful extras: real-time power (W), indoor temperature, mode sensor, dry/aux-heat switches

## Verification (real hardware, 2026-07-16)

- subtype/modelNumber 524 confirmed against the live MSmartHome appliance list for this device
- with the profile installed: `set_temperature(16)` accepted through HA, mirrored back as 16, and the unit held/ran a full day of cloud control at 16 (previously: hard 500 from the min_temp validation)
- boost/eco/comfort presets, fan speeds incl. auto (102), off/vertical swing, and the power sensor all verified working against the live unit
- `hassfest`/HACS validation unaffected (device_mapping data only)

Developed with AI assistance for the lua analysis and mapping work (as CONTRIBUTING.md suggests), and validated end-to-end on the physical device by me.