### PR TITLE
fix: self-heal cloud session loss; mark entities unavailable and surface control failures

### DIFF
--- a/custom_components/midea_auto_cloud/core/cloud.py
+++ b/custom_components/midea_auto_cloud/core/cloud.py
@@ -40,6 +40,9 @@ default_keys = {
     }
 }
 
+# 重新登录节流：一次登录尝试失败后，至少间隔该秒数才允许下一次尝试，避免登录风暴
+RELOGIN_RETRY_COOLDOWN = 60
+
 class MideaCloud:
     def __init__(
             self,
@@ -66,6 +69,10 @@ class MideaCloud:
         self._relogin_lock = asyncio.Lock()
         # token 失效（如 40002 user token not exist）时自动重新登录并重试请求
         self._auto_relogin_on_token_invalid = True
+        # 最近一次重新登录尝试的时间（monotonic），用于节流
+        self._last_relogin_attempt = float("-inf")
+        # 正在执行 login() 的任务，用于避免登录流程内部的请求递归触发重登（死锁）
+        self._relogin_task: asyncio.Task | None = None
         self._on_login_success = None
         # 仅 /status/lua/get 可能返回 1014 lua analysis exception
         self._lua_status_analysis_error = False
@@ -118,6 +125,47 @@ class MideaCloud:
         return "lua analysis exception" in msg
 
     @staticmethod
+    def _is_login_endpoint(endpoint: str) -> bool:
+        """登录流程自身使用的接口：不参与自动重登/计数清零，避免递归与死锁。"""
+        return "/user/login" in endpoint or "/unitcenter/router/" in endpoint
+
+    async def _ensure_logged_in(self) -> bool:
+        """访问令牌缺失时自动重新登录（带节流）。
+
+        会话失效后若当场重登失败（如云端瞬时故障返回非 JSON），旧实现不会再有
+        任何登录重试，集成会永久停留在未登录状态：轮询与控制全部静默失败。
+        这里在每次业务请求前补一次登录机会，保证会话可自愈。
+        """
+        if self._access_token is not None:
+            return True
+        if self._relogin_task is asyncio.current_task():
+            # login() 流程内部的嵌套请求，直接放行，避免对自身锁死锁
+            return False
+        async with self._relogin_lock:
+            if self._access_token is not None:
+                return True
+            now = time.monotonic()
+            if now - self._last_relogin_attempt < RELOGIN_RETRY_COOLDOWN:
+                return False
+            self._last_relogin_attempt = now
+            self._relogin_task = asyncio.current_task()
+            try:
+                MideaLogger.warning("Midea cloud session已丢失，尝试自动重新登录。")
+                if await self.login():
+                    self._token_invalid_retry_count = 0
+                    MideaLogger.info("Midea cloud 自动重新登录成功。")
+                    return True
+                MideaLogger.warning(
+                    f"Midea cloud 自动重新登录失败，{RELOGIN_RETRY_COOLDOWN}秒后随下次请求重试。"
+                )
+                return False
+            except Exception:
+                traceback.print_exc()
+                return False
+            finally:
+                self._relogin_task = None
+
+    @staticmethod
     def _is_token_invalid_response(response: dict) -> bool:
         try:
             code = int(response.get("code", -1))
@@ -153,6 +201,14 @@ class MideaCloud:
             data.update({
                 "stamp":  datetime.datetime.now().strftime("%Y%m%d%H%M%S")
             })
+        # 会话已丢失（如重登失败后）时先尝试恢复登录，修复“登录失败后永不重试”的死状态
+        if (
+            self._auto_relogin_on_token_invalid
+            and self._access_token is None
+            and not _retried_after_login
+            and not self._is_login_endpoint(endpoint)
+        ):
+            await self._ensure_logged_in()
         random = str(int(time.time()))
         url = self._api_url + endpoint
         dump_data = json.dumps(data)
@@ -191,9 +247,9 @@ class MideaCloud:
             traceback.print_exc()
 
         if int(response["code"]) == 0:
-            # 只在“重试后的业务请求”成功时才清零计数
-            # 否则 login() 过程中也会返回 code==0，从而把计数过早重置导致永远无法累计到上限。
-            if _retried_after_login:
+            # 业务请求成功即可清零计数；登录流程自身的 code==0 不算
+            # （login() 过程中也会返回 code==0，若计入会把计数过早重置）。
+            if _retried_after_login or not self._is_login_endpoint(endpoint):
                 self._token_invalid_retry_count = 0
             if "data" in response:
                 return response["data"]
@@ -210,23 +266,35 @@ class MideaCloud:
         if (
             self._auto_relogin_on_token_invalid
             and not _retried_after_login
+            and not self._is_login_endpoint(endpoint)
+            and self._relogin_task is not asyncio.current_task()
             and isinstance(response, dict)
             and self._is_token_invalid_response(response)
         ):
             if self._token_invalid_retry_count >= 3:
-                MideaLogger.warning(
-                    "Midea cloud token失效重试次数过多，已跳过后续登录重试。"
-                    f"endpoint={endpoint}, retry_count={self._token_invalid_retry_count}"
-                )
-                return None
+                if time.monotonic() - self._last_relogin_attempt < RELOGIN_RETRY_COOLDOWN:
+                    MideaLogger.warning(
+                        "Midea cloud token失效重试次数过多，冷却期内跳过登录重试。"
+                        f"endpoint={endpoint}, retry_count={self._token_invalid_retry_count}"
+                    )
+                    return None
+                # 冷却期已过：重置计数继续尝试，避免永久放弃登录
+                self._token_invalid_retry_count = 0
             self._token_invalid_retry_count += 1
             MideaLogger.warning(f"Midea cloud token失效，准备重新登录后重试请求。endpoint={endpoint}, retry_count={self._token_invalid_retry_count}, code={response.get('code')}, msg={response.get('msg') or response.get('message')}")
             self._access_token = None
             try:
                 async with self._relogin_lock:
                     if self._access_token is None:
-                        if not await self.login():
+                        if time.monotonic() - self._last_relogin_attempt < RELOGIN_RETRY_COOLDOWN:
                             return None
+                        self._last_relogin_attempt = time.monotonic()
+                        self._relogin_task = asyncio.current_task()
+                        try:
+                            if not await self.login():
+                                return None
+                        finally:
+                            self._relogin_task = None
                 return await self._api_request(
                     endpoint=endpoint,
                     data=data,
@@ -486,6 +554,13 @@ class MeijuCloud(MideaCloud):
     ) -> dict | None:
         """家用空调 jykt 接口，响应格式为 errCode/result 而非 code/data。"""
         header = header or {}
+        # 会话已丢失时先尝试恢复登录（带节流），与 _api_request 保持一致
+        if (
+            self._auto_relogin_on_token_invalid
+            and self._access_token is None
+            and not _retried_after_login
+        ):
+            await self._ensure_logged_in()
         random = str(int(time.time() * 1000))
         url = self._api_url + endpoint
         dump_data = json.dumps(data)
@@ -536,22 +611,33 @@ class MeijuCloud(MideaCloud):
         if (
             self._auto_relogin_on_token_invalid
             and not _retried_after_login
+            and self._relogin_task is not asyncio.current_task()
             and isinstance(response, dict)
             and self._is_token_invalid_response(response)
         ):
             if self._token_invalid_retry_count >= 3:
-                MideaLogger.warning(
-                    "Midea cloud token失效重试次数过多，已跳过后续登录重试。"
-                    f"endpoint={endpoint}, retry_count={self._token_invalid_retry_count}"
-                )
-                return None
+                if time.monotonic() - self._last_relogin_attempt < RELOGIN_RETRY_COOLDOWN:
+                    MideaLogger.warning(
+                        "Midea cloud token失效重试次数过多，冷却期内跳过登录重试。"
+                        f"endpoint={endpoint}, retry_count={self._token_invalid_retry_count}"
+                    )
+                    return None
+                # 冷却期已过：重置计数继续尝试，避免永久放弃登录
+                self._token_invalid_retry_count = 0
             self._token_invalid_retry_count += 1
             self._access_token = None
             try:
                 async with self._relogin_lock:
                     if self._access_token is None:
-                        if not await self.login():
+                        if time.monotonic() - self._last_relogin_attempt < RELOGIN_RETRY_COOLDOWN:
                             return None
+                        self._last_relogin_attempt = time.monotonic()
+                        self._relogin_task = asyncio.current_task()
+                        try:
+                            if not await self.login():
+                                return None
+                        finally:
+                            self._relogin_task = None
                 return await self._jykt_api_request(
                     endpoint=endpoint,
                     data=data,
@@ -984,7 +1070,17 @@ class MSmartHomeCloud(MideaCloud):
             header.update({
                 "uid": self._uid
             })
-        return await super()._api_request(endpoint, data, header, print_log=True)
+        # 必须透传 method 与 _retried_after_login：
+        # 丢失 _retried_after_login 会让基类的“重试成功后清零计数”永远不生效，
+        # token 失效计数只增不减，累计 3 次后自动重登被永久跳过。
+        return await super()._api_request(
+            endpoint,
+            data,
+            header,
+            method=method,
+            _retried_after_login=_retried_after_login,
+            print_log=True,
+        )
 
     async def _re_route(self):
         data = self._make_general_data()

--- a/custom_components/midea_auto_cloud/core/cloud.py
+++ b/custom_components/midea_auto_cloud/core/cloud.py
@@ -153,7 +153,7 @@ class MideaCloud:
                 MideaLogger.warning("Midea cloud session已丢失，尝试自动重新登录。")
                 if await self.login():
                     self._token_invalid_retry_count = 0
-                    MideaLogger.info("Midea cloud 自动重新登录成功。")
+                    MideaLogger.warning("Midea cloud 自动重新登录成功。")
                     return True
                 MideaLogger.warning(
                     f"Midea cloud 自动重新登录失败，{RELOGIN_RETRY_COOLDOWN}秒后随下次请求重试。"

--- a/custom_components/midea_auto_cloud/core/device.py
+++ b/custom_components/midea_auto_cloud/core/device.py
@@ -352,13 +352,13 @@ class MiedaDevice(threading.Thread):
             if key not in excluded
         }
 
-    async def set_attribute(self, attribute, value):
+    async def set_attribute(self, attribute, value) -> bool:
         if attribute in self._attributes.keys():
             new_status = {}
             for attr in self._centralized:
                 new_status[attr] = self._attributes.get(attr)
             new_status[attribute] = value
-            
+
             # 针对T0xD9复式洗衣机，当本地变更 db_location_selection 时，调整 db_location
             if self._device_type == 0xD9:
                 if attribute == "db_location_selection":
@@ -375,8 +375,7 @@ class MiedaDevice(threading.Thread):
             if self._lua_runtime is not None:
                 try:
                     if set_cmd := self._lua_runtime.build_control(nested_status, status=status_for_lua):
-                        await self._build_send(set_cmd)
-                        return
+                        return await self._build_send(set_cmd)
                 except Exception as e:
                     MideaLogger.debug(f"LuaRuntimeError in set_attribute {nested_status}: {repr(e)}")
                     traceback.print_exc()
@@ -384,7 +383,7 @@ class MiedaDevice(threading.Thread):
             cloud = self._cloud
             if cloud and hasattr(cloud, "send_device_control"):
                 if isinstance(cloud, MSmartHomeCloud):
-                    await cloud.send_device_control(
+                    return await cloud.send_device_control(
                         appliance_code=self._device_id,
                         device_type=self.device_type,
                         sn=self.sn,
@@ -393,9 +392,12 @@ class MiedaDevice(threading.Thread):
                         control=nested_status,
                         status=status_for_lua)
                 elif isinstance(cloud, MeijuCloud):
-                    await cloud.send_device_control(self._device_id, control=nested_status, status=status_for_lua)
+                    return await cloud.send_device_control(self._device_id, control=nested_status, status=status_for_lua)
+            return False
+        return True
 
-    async def set_attributes(self, attributes):
+    async def set_attributes(self, attributes) -> bool:
+        """下发控制。返回控制是否送达（云端确认/设备应答），供调用方上报失败。"""
         new_status = {}
         for attr in self._centralized:
             new_status[attr] = self._attributes.get(attr)
@@ -404,7 +406,7 @@ class MiedaDevice(threading.Thread):
             if attribute in self._attributes.keys() or attribute in LAMP_CONTROL_KEYS:
                 has_new = True
                 new_status[attribute] = value
-    
+
         # 针对T0xD9复式洗衣机，根据 db_location_selection 调整 db_location
         if self._device_type == 0xD9:
             if "db_location_selection" in attributes:
@@ -417,13 +419,12 @@ class MiedaDevice(threading.Thread):
         # Convert dot-notation attributes to nested structure for transmission
         nested_status = self._convert_to_nested_structure(new_status)
         status_for_lua = self._status_for_lua_control(new_status)
-        
+
         if has_new:
             if self._lua_runtime is not None:
                 try:
                     if set_cmd := self._lua_runtime.build_control(nested_status, status=status_for_lua):
-                        await self._build_send(set_cmd)
-                        return
+                        return await self._build_send(set_cmd)
                 except Exception as e:
                     MideaLogger.debug(f"LuaRuntimeError in set_attributes {nested_status}: {repr(e)}")
                     traceback.print_exc()
@@ -431,7 +432,7 @@ class MiedaDevice(threading.Thread):
             cloud = self._cloud
             if cloud and hasattr(cloud, "send_device_control"):
                 if isinstance(cloud, MSmartHomeCloud):
-                    await cloud.send_device_control(
+                    return await cloud.send_device_control(
                         appliance_code=self._device_id,
                         device_type=self.device_type,
                         sn=self.sn,
@@ -440,7 +441,9 @@ class MiedaDevice(threading.Thread):
                         control=nested_status,
                         status=status_for_lua)
                 elif isinstance(cloud, MeijuCloud):
-                    await cloud.send_device_control(self._device_id, control=nested_status, status=status_for_lua)
+                    return await cloud.send_device_control(self._device_id, control=nested_status, status=status_for_lua)
+            return False
+        return True
 
     def set_ip_address(self, ip_address):
         MideaLogger.debug(f"Update IP address to {ip_address}")
@@ -497,12 +500,15 @@ class MiedaDevice(threading.Thread):
         data = self._security.encode_8370(data, msg_type)
         self._send_message_v2(data)
 
-    async def _build_send(self, cmd: str):
+    async def _build_send(self, cmd: str) -> bool:
         MideaLogger.debug(f"Sending: {cmd.lower()}")
         bytes_cmd = bytes.fromhex(cmd)
-        await self._send_message(bytes_cmd)
+        return await self._send_message(bytes_cmd)
 
-    async def refresh_status(self):
+    async def refresh_status(self) -> bool:
+        """刷新设备状态。返回是否有任一查询取得了数据（用于可用性判断）。"""
+        any_success = False
+        attempted = False
         for query in self._queries:
             query_sig = self._query_signature(query)
             if query_sig in self._skipped_queries:
@@ -519,6 +525,7 @@ class MiedaDevice(threading.Thread):
 
             cloud = self._cloud
             if cloud and hasattr(cloud, "get_device_status"):
+                attempted = True
                 if isinstance(cloud, MSmartHomeCloud):
                     if status := await cloud.get_device_status(
                         appliance_code=self._device_id,
@@ -529,6 +536,7 @@ class MiedaDevice(threading.Thread):
                         query=actual_query
                     ):
                         self._parse_cloud_message(status)
+                        any_success = True
                     elif cloud.lua_status_analysis_error:
                         self._skipped_queries.add(query_sig)
                         MideaLogger.warning(
@@ -538,7 +546,8 @@ class MiedaDevice(threading.Thread):
                     else:
                         if self._lua_runtime is not None:
                             if query_cmd := self._lua_runtime.build_query(actual_query):
-                                await self._build_send(query_cmd)
+                                if await self._build_send(query_cmd):
+                                    any_success = True
 
                 elif isinstance(cloud, MeijuCloud):
                     if status := await cloud.get_device_status(
@@ -546,6 +555,7 @@ class MiedaDevice(threading.Thread):
                         query=actual_query
                     ):
                         self._parse_cloud_message(status)
+                        any_success = True
                     elif cloud.lua_status_analysis_error:
                         self._skipped_queries.add(query_sig)
                         MideaLogger.warning(
@@ -555,7 +565,11 @@ class MiedaDevice(threading.Thread):
                     else:
                         if self._lua_runtime is not None:
                             if query_cmd := self._lua_runtime.build_query(actual_query):
-                                await self._build_send(query_cmd)
+                                if await self._build_send(query_cmd):
+                                    any_success = True
+
+        # 没有执行任何云端查询时（如查询全部被跳过）不算失败
+        return any_success or not attempted
 
 
     def _parse_cloud_message(self, status, update=True):
@@ -638,7 +652,8 @@ class MiedaDevice(threading.Thread):
                             self._update_all(new_status)
         return ParseMessageResult.SUCCESS
 
-    async def _send_message(self, data):
+    async def _send_message(self, data) -> bool:
+        """经云端透传发送。返回设备是否给出了应答（用于失败上报）。"""
         if reply := await self._cloud.send_cloud(self._device_id, data):
             if reply_dec := self._lua_runtime.decode_status(dec_string_to_bytes(reply).hex()):
                 MideaLogger.debug(f"Decoded: {reply_dec}")
@@ -647,6 +662,8 @@ class MiedaDevice(threading.Thread):
                     MideaLogger.debug(f"Message 'ERROR' received")
                 elif result == ParseMessageResult.SUCCESS:
                     timeout_counter = 0
+            return True
+        return False
 
     # if self._protocol == 3:
     #     self._send_message_v3(data, msg_type=MSGTYPE_ENCRYPTED_REQUEST)

--- a/custom_components/midea_auto_cloud/data_coordinator.py
+++ b/custom_components/midea_auto_cloud/data_coordinator.py
@@ -8,6 +8,7 @@ from typing import Any, NamedTuple
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
@@ -15,6 +16,9 @@ from .core.device import MiedaDevice
 from .core.logger import MideaLogger
 
 _LOGGER = logging.getLogger(__name__)
+
+# 连续轮询失败达到该次数后，将实体标记为不可用（成功一次即恢复）
+MAX_CONSECUTIVE_POLL_FAILURES = 3
 
 
 class MideaDeviceData(NamedTuple):
@@ -58,6 +62,8 @@ class MideaDataUpdateCoordinator(DataUpdateCoordinator[MideaDeviceData]):
         # device callbacks mid-refresh (resets the poll timer and races the
         # coordinator's own listener notification).
         self._polling = False
+        # 连续轮询失败计数：会话失效/设备离线时不再假装一切正常
+        self._consecutive_poll_failures = 0
 
     async def _async_setup(self) -> None:
         """Set up the coordinator."""
@@ -104,9 +110,16 @@ class MideaDataUpdateCoordinator(DataUpdateCoordinator[MideaDeviceData]):
         """
         connected = self.device.connected
         if available is None:
-            # Cloud appliances remain controllable even when Midea reports them
-            # offline at list time (onlineStatus != 1).
-            available = True if self._is_cloud_only_device() else connected
+            if self._is_cloud_only_device():
+                # Cloud appliances remain controllable even when Midea reports
+                # them offline at list time (onlineStatus != 1) — but repeated
+                # poll failures (dead session, device offline) must surface as
+                # unavailable instead of freezing entities at stale values.
+                available = (
+                    self._consecutive_poll_failures < MAX_CONSECUTIVE_POLL_FAILURES
+                )
+            else:
+                available = connected
         attrs = copy.deepcopy(self.device.attributes)
         self._flatten_nested_scalars(attrs)
         return MideaDeviceData(
@@ -144,23 +157,49 @@ class MideaDataUpdateCoordinator(DataUpdateCoordinator[MideaDeviceData]):
         # Update coordinator data (fresh snapshot so HA detects the change)
         self.async_set_updated_data(self._snapshot())
 
+    def _track_poll_result(self, success: bool) -> None:
+        """记录轮询结果；连续失败达到阈值后标记不可用，成功一次即恢复。"""
+        if success:
+            if self._consecutive_poll_failures >= MAX_CONSECUTIVE_POLL_FAILURES:
+                _LOGGER.info(
+                    "Device %s (%s) recovered after %s failed polls",
+                    self.device.device_name,
+                    self._device_id,
+                    self._consecutive_poll_failures,
+                )
+            self._consecutive_poll_failures = 0
+            return
+        self._consecutive_poll_failures += 1
+        if self._consecutive_poll_failures == MAX_CONSECUTIVE_POLL_FAILURES:
+            _LOGGER.warning(
+                "Device %s (%s) failed %s consecutive polls; "
+                "marking entities unavailable until data flows again",
+                self.device.device_name,
+                self._device_id,
+                self._consecutive_poll_failures,
+            )
+
     async def poll_device_state(self) -> MideaDeviceData:
         """Poll device state."""
         if self.state_update_muted:
             return self.data
 
+        refresh_ok = True
         self._polling = True
         try:
             # 检查是否为中央空调设备（T0x21）
             if self.device.device_type == 0x21:
                 await self._poll_central_ac_state()
             else:
-                await self.device.refresh_status()
+                refresh_ok = await self.device.refresh_status()
         except Exception as e:
+            refresh_ok = False
             traceback.print_exc()
             _LOGGER.error(f"Error polling device state: {e}")
         finally:
             self._polling = False
+
+        self._track_poll_result(refresh_ok)
 
         try:
             await self._poll_cloud_stats()
@@ -439,7 +478,21 @@ class MideaDataUpdateCoordinator(DataUpdateCoordinator[MideaDeviceData]):
         
         # 只发送没有默认值的属性到云端
         if attributes_to_send:
-            await self.device.set_attributes(attributes_to_send)
+            if not await self.device.set_attributes(attributes_to_send):
+                # 控制未送达（会话失效/设备离线）：如实报错，
+                # 不做乐观镜像，避免 UI 显示一个设备从未收到的状态。
+                _LOGGER.warning(
+                    "Failed to send control to %s (%s): %s",
+                    self.device.device_name,
+                    self._device_id,
+                    attributes_to_send,
+                )
+                raise HomeAssistantError(
+                    f"Failed to send command to Midea device "
+                    f"{self.device.device_name} ({self._device_id})"
+                )
+            # 控制送达说明云端会话与设备均正常，清零失败计数
+            self._track_poll_result(True)
         # 更新所有属性到本地状态（包括有默认值的变量）
         self.device.attributes.update(attributes)
         self.mute_state_update_for_a_while()

--- a/custom_components/midea_auto_cloud/data_coordinator.py
+++ b/custom_components/midea_auto_cloud/data_coordinator.py
@@ -161,7 +161,7 @@ class MideaDataUpdateCoordinator(DataUpdateCoordinator[MideaDeviceData]):
         """记录轮询结果；连续失败达到阈值后标记不可用，成功一次即恢复。"""
         if success:
             if self._consecutive_poll_failures >= MAX_CONSECUTIVE_POLL_FAILURES:
-                _LOGGER.info(
+                _LOGGER.warning(
                     "Device %s (%s) recovered after %s failed polls",
                     self.device.device_name,
                     self._device_id,


### PR DESCRIPTION
## 中文摘要

云端 token 失效（40002）且当场自动重登失败后，集成会永久停留在未登录状态：轮询与控制全部静默返回 None，实体既不更新也不标记不可用，UI 还会乐观镜像设备从未收到的指令，只有重载配置条目才能恢复。本 PR 为会话增加带节流的自动重登（自愈）、连续轮询失败后将实体标记为不可用、控制未送达时如实报错，并修复 MSmartHome 覆写丢失 `_retried_after_login` 导致的失效计数只增不减问题。

## Problem

After the cloud invalidates the access token (code 40002 `user token not exist`), the integration clears the token and attempts exactly one re-login. If that single attempt fails — e.g. the cloud API is transiently unstable and returns non-JSON, which is precisely when tokens tend to get invalidated — nothing ever tries to log in again. Every subsequent poll and control request is sent without a token and fails with error codes that are not classified as token-invalid, so each one silently returns `None`:

- all entities freeze at their last values indefinitely and are never marked unavailable;
- service calls (e.g. `climate.set_hvac_mode`) appear to succeed and the UI optimistically mirrors a state the device never received;
- the only recovery is reloading the config entry.

Observed in production on a T0xAC (subtype 524) appliance: token invalidated at 02:53, exactly one `token失效…retry_count=1` warning, then 10.5 hours of complete silence with frozen entities and swallowed commands while the native MSmartHome app worked fine.

Two aggravating bugs: `MSmartHomeCloud._api_request` does not forward `_retried_after_login` to the base class, so the retry counter can never be reset on success — after 3 token-invalid events over the lifetime of the session object, auto-relogin is *permanently* skipped. And a token-invalid response to one of the login endpoints themselves would re-acquire `_relogin_lock` from the task already holding it — a deadlock.

## Solution

- **Session self-healing**: before any business request, if the access token is missing, attempt a re-login (throttled to one attempt per 60 s, serialized on the existing `_relogin_lock`). A failed re-login is no longer terminal — the session recovers as soon as the cloud does.
- **Retry counter fixes**: reset on any successful business request (login endpoints excluded); the `>= 3` cap now only skips re-login during the cooldown window instead of forever; `MSmartHomeCloud._api_request` forwards `method` and `_retried_after_login`.
- **Deadlock guards**: the token-invalid retry path is skipped for login-flow endpoints and for requests issued from within `login()` itself.
- **Availability**: `refresh_status()` reports whether any query yielded data; after 3 consecutive failed polls the coordinator marks entities unavailable (single warning), recovering on the first success. Cloud devices listed `onlineStatus != 1` remain available as before.
- **Honest controls**: `set_attribute(s)` report whether the cloud/device acknowledged; on failure the coordinator raises `HomeAssistantError` and skips the optimistic state mirror, so failures surface in the UI and automation traces.

## Verification

- `python3 -m py_compile` on all integration files.
- Offline replay harness against a scripted session: token death + failed re-login + tokenless polls, then cloud recovery → automatic re-login, fresh token on the next request, counter resets; normal 40002→relogin→retry flow unchanged; no deadlocks.
- **Live (production box, 2026-07-18):** after the appliance's routine mains unplug, entities were marked unavailable after exactly 3 failed polls with the new single warning line (`failed 3 consecutive polls; marking entities unavailable until data flows again`) — previously they froze silently forever. Recovery-without-reload will be exercised on the next re-plug cycle of the same routine.

## Related finding (out of scope here)

`device.py`'s `send_command()` creates the `_build_send(...)` coroutine without awaiting it, so the custom-command path has likely never executed for cloud devices. Happy to file separately.

This PR was developed with AI assistance.