### PR TITLE
fix: support wind_speed.level control on flat 17100001 AC models

### DIFF
--- a/custom_components/midea_auto_cloud/core/device.py
+++ b/custom_components/midea_auto_cloud/core/device.py
@@ -293,6 +293,28 @@ class MiedaDevice(threading.Thread):
             value = value[key]
         return True
 
+    def _has_attribute(self, attribute: str) -> bool:
+        attrs = self._attributes if isinstance(self._attributes, dict) else {}
+        if not attrs or attribute in attrs or attribute in LAMP_CONTROL_KEYS:
+            return True
+        if "." in attribute and attribute.replace(".", "_") in attrs:
+            return True
+        if "." in attribute and self._has_nested_path(attrs, attribute):
+            return True
+        return False
+
+    def _get_existing_attr_value(self, attrs: dict, key: str) -> Any:
+        if self._has_nested_path(attrs, key):
+            val = attrs
+            for k in key.split("."):
+                val = val[k]
+            return val
+        if "." in key:
+            underscore = key.replace(".", "_")
+            if underscore in attrs:
+                return attrs[underscore]
+        return attrs.get(key)
+
     def _convert_to_nested_structure(self, attributes):
         """Convert control keys to the device's wire format.
 
@@ -304,6 +326,10 @@ class MiedaDevice(threading.Thread):
         nested = {}
         attrs = self._attributes if isinstance(self._attributes, dict) else {}
         for key, value in attributes.items():
+            existing = self._get_existing_attr_value(attrs, key)
+            if isinstance(existing, str) and not isinstance(value, (str, dict, list)):
+                value = str(value)
+
             if "." not in key:
                 nested[key] = value
                 continue
@@ -353,7 +379,7 @@ class MiedaDevice(threading.Thread):
         }
 
     async def set_attribute(self, attribute, value):
-        if attribute in self._attributes.keys():
+        if self._has_attribute(attribute):
             new_status = {}
             for attr in self._centralized:
                 new_status[attr] = self._attributes.get(attr)
@@ -401,7 +427,7 @@ class MiedaDevice(threading.Thread):
             new_status[attr] = self._attributes.get(attr)
         has_new = False
         for attribute, value in attributes.items():
-            if attribute in self._attributes.keys() or attribute in LAMP_CONTROL_KEYS:
+            if self._has_attribute(attribute):
                 has_new = True
                 new_status[attribute] = value
     

--- a/custom_components/midea_auto_cloud/core/device.py
+++ b/custom_components/midea_auto_cloud/core/device.py
@@ -379,7 +379,7 @@ class MiedaDevice(threading.Thread):
         }
 
     async def set_attribute(self, attribute, value) -> bool:
-        if attribute in self._attributes.keys():
+        if self._has_attribute(attribute):
             new_status = {}
             for attr in self._centralized:
                 new_status[attr] = self._attributes.get(attr)


### PR DESCRIPTION
Fixes #216

## Description
Fixes an issue where fan speed control (`wind_speed.level`) fails to apply on T0xCC AC models with flat status payloads (such as flat `17100001` / `#216`-style devices).

## Problem & Root Cause
1. **Attribute Membership Check**: In `set_attribute` and `set_attributes`, key existence was checked via `attribute in self._attributes.keys()`. When default climate mappings pass dotted keys like `"wind_speed.level"`, but flat devices store underscore keys in `self._attributes` (e.g. `"wind_speed_level"`), `attribute in self._attributes.keys()` evaluated to `False`. The fan speed command was silently dropped and never dispatched.
2. **Wire Format Type Mismatch**: Default climate entity mappings pass integer speed levels (e.g. `4`), whereas flat T0xCC status payloads report speed levels as strings (`"4"`). Passing raw integer values to cloud/codec payloads for devices that report string attributes caused control commands to be rejected.

## Proposed Changes
- **`_has_attribute(attribute)`**: Added a helper method in `MiedaDevice` to verify attribute presence across direct keys (`"wind_speed.level"`), underscore aliases (`"wind_speed_level"`), and nested dictionary paths (`"wind_speed" -> "level"`).
- **Wire Type Match (`_convert_to_nested_structure`)**: Updated payload generation so numerical control values (e.g. `4`) are automatically converted to string format (`"4"`) when the existing attribute in `self._attributes` is a string.

## Verification
- Verified against flat `17100001` T0xCC status payloads where `wind_speed_level` and `wind_speed.level` are reported as `"4"`.
- Confirmed syntax and compilation via `py_compile`.
