### PR TITLE
fix: import Any in core/device.py (integration fails to import on v0.4.11)

### DIFF
--- a/custom_components/midea_auto_cloud/core/device.py
+++ b/custom_components/midea_auto_cloud/core/device.py
@@ -1,3 +1,4 @@
+from typing import Any
 import threading
 import socket
 import traceback


### PR DESCRIPTION
Fixes #231

`core/device.py` line 306 uses `Any` in a return annotation:

```python
def _get_existing_attr_value(self, attrs: dict, key: str) -> Any:
```

but the module never imports it. Annotations on methods are evaluated when the class body executes, so the module raises `NameError: name 'Any' is not defined` at import time and the whole integration fails to set up ("Invalid config") after updating to v0.4.11.

This PR adds the missing `from typing import Any`.

Verified on HA 2026.1.3 (Python 3.13): with this one-line patch applied, the integration imports and all entities recover after a config-entry reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)