### PR TITLE
fix: send screen_display as numeric so codec crc8 stops crashing (T0xAC)

### DIFF
--- a/custom_components/midea_auto_cloud/device_mapping/T0xAC.py
+++ b/custom_components/midea_auto_cloud/device_mapping/T0xAC.py
@@ -368,10 +368,6 @@ DEVICE_MAPPING = {
         "calculate": {
             "get": [
                 {
-                    "lvalue": "[screen_display]",
-                    "rvalue": "[screen_display_now]"
-                },
-                {
                     "lvalue": "[real_time_power_value]",
                     "rvalue": "float([real_time_power]) / 10"
                 },
@@ -466,7 +462,11 @@ DEVICE_MAPPING = {
                 },
                 "screen_display": {
                     "device_class": SwitchDeviceClass.SWITCH,
-                    "translation_key": "display_on_off"
+                    "translation_key": "display_on_off",
+                    # Codec expects a numeric screen_display; read live on/off
+                    # state from screen_display_now.
+                    "state_attribute": "screen_display_now",
+                    "rationale": [0, 100],
                 },
                 "prevent_straight_wind": {
                     "device_class": SwitchDeviceClass.SWITCH,
@@ -528,12 +528,7 @@ DEVICE_MAPPING = {
         ],
         "centralized": ["buzzer"],
         "calculate":{
-            "get": [
-                {
-                    "lvalue": "[screen_display]",
-                    "rvalue": "[screen_display_now]"
-                },
-            ],
+            "get": [],
             "set": []
         },
         "entities": {
@@ -609,7 +604,11 @@ DEVICE_MAPPING = {
                 },
                 "screen_display": {
                     "device_class": SwitchDeviceClass.SWITCH,
-                    "translation_key": "display_on_off"
+                    "translation_key": "display_on_off",
+                    # Codec expects a numeric screen_display; read live on/off
+                    # state from screen_display_now.
+                    "state_attribute": "screen_display_now",
+                    "rationale": [0, 100],
                 },
                 "prevent_straight_wind": {
                     "device_class": SwitchDeviceClass.SWITCH,
@@ -2209,12 +2208,7 @@ DEVICE_MAPPING = {
                     {"query_type": "wind_swing_ud_angle"}, {"query_type": "wind_swing_lr_angle"}],
         "centralized": ["buzzer"],
         "calculate":{
-            "get": [
-                {
-                    "lvalue": "[screen_display]",
-                    "rvalue": "[screen_display_now]"
-                },
-            ],
+            "get": [],
             "set": []
         },
         "entities": {
@@ -2292,6 +2286,10 @@ DEVICE_MAPPING = {
                 "screen_display": {
                     "device_class": SwitchDeviceClass.SWITCH,
                     "translation_key": "screen_close",
+                    # Codec expects a numeric screen_display; read live on/off
+                    # state from screen_display_now.
+                    "state_attribute": "screen_display_now",
+                    "rationale": [0, 100],
                 },
                 "prevent_straight_wind": {
                     "device_class": SwitchDeviceClass.SWITCH,
@@ -2331,12 +2329,7 @@ DEVICE_MAPPING = {
                     {"query_type": "wind_swing_ud_angle"}, {"query_type": "wind_swing_lr_angle"}],
         "centralized": ["buzzer"],
         "calculate":{
-            "get": [
-                {
-                    "lvalue": "[screen_display]",
-                    "rvalue": "[screen_display_now]"
-                },
-            ],
+            "get": [],
             "set": []
         },
         "entities": {
@@ -2422,6 +2415,10 @@ DEVICE_MAPPING = {
                 "screen_display": {
                     "device_class": SwitchDeviceClass.SWITCH,
                     "translation_key": "screen_close",
+                    # Codec expects a numeric screen_display; read live on/off
+                    # state from screen_display_now.
+                    "state_attribute": "screen_display_now",
+                    "rationale": [0, 100],
                 },
                 "prevent_super_cool": {
                     "device_class": SwitchDeviceClass.SWITCH,

--- a/custom_components/midea_auto_cloud/switch.py
+++ b/custom_components/midea_auto_cloud/switch.py
@@ -52,8 +52,14 @@ class MideaSwitchEntity(MideaEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return if the switch is on."""
-        # Use attribute from config if available, otherwise fall back to entity_key
-        attribute = self._config.get("attribute", self._entity_key)
+        # Prefer an explicit read-only state attribute; otherwise fall back to
+        # the write attribute / entity_key. This lets a switch report state from
+        # one attribute (e.g. the string on/off ``screen_display_now``) while
+        # writing to another (e.g. the numeric ``screen_display`` the codec
+        # expects).
+        attribute = self._config.get("state_attribute") or self._config.get(
+            "attribute", self._entity_key
+        )
         return self._get_status_on_off(attribute)
 
     async def async_turn_on(self):


### PR DESCRIPTION
## 问题 / Problem
壁挂式空调的「屏显」开关无法控制，`switch.turn_off` 报 `Failed to send command`。
根因：`calculate.get` 里的规则 `screen_display = screen_display_now` 把数值 `screen_display`（如 `100`）覆盖成了字符串 `"on"/"off"`；开关又用默认 `["off","on"]` rationale，于是 `turn_off` 下发 `screen_display: "off"`。而 Lua 编解码器把它当数值做 crc8 运算，字符串就会触发崩溃：

The `screen_display` switch on wall ACs can't be controlled — `switch.turn_off` raises `Failed to send command`.
Root cause: the `calculate.get` rule `screen_display = screen_display_now` overwrites the numeric `screen_display` (e.g. `100`) with the string `"on"/"off"`. With the default `["off","on"]` rationale, `turn_off` sends `screen_display: "off"`, and the Lua codec treats it as a numeric byte and runs crc8 over it, so a string crashes:

```
bit.lua:231: attempt to perform arithmetic on local 'b' (a string value)
  in function 'crc8_854'
```

本地编解码器和云端都会拒绝该命令（云端返回 `code 1014 "lua analysis exception"`）。该错误自 #225 起才被暴露，之前被乐观 UI 镜像静默吞掉了。
Both the local codec and the cloud reject the command (cloud returns `code 1014 "lua analysis exception"`). This only surfaced as an error since #225; before that it was silently swallowed by the optimistic UI mirror.

## 修复 / Fix

- `switch.py`：新增可选 `state_attribute`，让开关从一个属性读状态、向另一个属性写入；向后兼容。
  `switch.py`: add an optional `state_attribute` so a switch reads its on/off state from one attribute and writes another. Backward compatible.
- `T0xAC.py`：删除 4 个块里的污染 calc 规则；`screen_display` 开关改为从 `screen_display_now` 读状态，通过 `rationale: [0, 100]` 写数值。
  `T0xAC.py`: drop the corrupting calc rule in the 4 affected blocks; the switch now reads state from `screen_display_now` and writes numeric `screen_display` via `rationale: [0, 100]`.

## 验证 / Verification

用日志里真实崩溃的 payload 针对真实设备 Lua 编解码器回放——字符串复现同样的 crc8 崩溃，数值则生成合法指令：`turn_off → …0024ac84`（`0x00`）、`turn_on → …6424cdff`（`0x64` = 100）。
Replayed the exact crashing payload from a log against the real device Lua codec — the string reproduces the crc8 crash, numeric builds valid commands: `turn_off → …0024ac84` (`0x00`), `turn_on → …6424cdff` (`0x64` = 100).

## 说明 / Note

`100=开 / 0=关` 是美的空调屏显的标准编码，已对本编解码器验证；其它 AC 型号的维护者可再确认「开」的取值。
`100=on / 0=off` is the standard Midea display encoding, proven for this codec; maintainers with other models may want to confirm the on-value.
