### PR TITLE
Revert "fix: send screen_display as numeric so codec crc8 stops crashing (T0xAC)"

### DIFF
--- a/custom_components/midea_auto_cloud/device_mapping/T0xAC.py
+++ b/custom_components/midea_auto_cloud/device_mapping/T0xAC.py
@@ -368,6 +368,10 @@ DEVICE_MAPPING = {
         "calculate": {
             "get": [
                 {
+                    "lvalue": "[screen_display]",
+                    "rvalue": "[screen_display_now]"
+                },
+                {
                     "lvalue": "[real_time_power_value]",
                     "rvalue": "float([real_time_power]) / 10"
                 },
@@ -462,11 +466,7 @@ DEVICE_MAPPING = {
                 },
                 "screen_display": {
                     "device_class": SwitchDeviceClass.SWITCH,
-                    "translation_key": "display_on_off",
-                    # Codec expects a numeric screen_display; read live on/off
-                    # state from screen_display_now.
-                    "state_attribute": "screen_display_now",
-                    "rationale": [0, 100],
+                    "translation_key": "display_on_off"
                 },
                 "prevent_straight_wind": {
                     "device_class": SwitchDeviceClass.SWITCH,
@@ -528,7 +528,12 @@ DEVICE_MAPPING = {
         ],
         "centralized": ["buzzer"],
         "calculate":{
-            "get": [],
+            "get": [
+                {
+                    "lvalue": "[screen_display]",
+                    "rvalue": "[screen_display_now]"
+                },
+            ],
             "set": []
         },
         "entities": {
@@ -604,11 +609,7 @@ DEVICE_MAPPING = {
                 },
                 "screen_display": {
                     "device_class": SwitchDeviceClass.SWITCH,
-                    "translation_key": "display_on_off",
-                    # Codec expects a numeric screen_display; read live on/off
-                    # state from screen_display_now.
-                    "state_attribute": "screen_display_now",
-                    "rationale": [0, 100],
+                    "translation_key": "display_on_off"
                 },
                 "prevent_straight_wind": {
                     "device_class": SwitchDeviceClass.SWITCH,
@@ -2208,7 +2209,12 @@ DEVICE_MAPPING = {
                     {"query_type": "wind_swing_ud_angle"}, {"query_type": "wind_swing_lr_angle"}],
         "centralized": ["buzzer"],
         "calculate":{
-            "get": [],
+            "get": [
+                {
+                    "lvalue": "[screen_display]",
+                    "rvalue": "[screen_display_now]"
+                },
+            ],
             "set": []
         },
         "entities": {
@@ -2286,10 +2292,6 @@ DEVICE_MAPPING = {
                 "screen_display": {
                     "device_class": SwitchDeviceClass.SWITCH,
                     "translation_key": "screen_close",
-                    # Codec expects a numeric screen_display; read live on/off
-                    # state from screen_display_now.
-                    "state_attribute": "screen_display_now",
-                    "rationale": [0, 100],
                 },
                 "prevent_straight_wind": {
                     "device_class": SwitchDeviceClass.SWITCH,
@@ -2329,7 +2331,12 @@ DEVICE_MAPPING = {
                     {"query_type": "wind_swing_ud_angle"}, {"query_type": "wind_swing_lr_angle"}],
         "centralized": ["buzzer"],
         "calculate":{
-            "get": [],
+            "get": [
+                {
+                    "lvalue": "[screen_display]",
+                    "rvalue": "[screen_display_now]"
+                },
+            ],
             "set": []
         },
         "entities": {
@@ -2415,10 +2422,6 @@ DEVICE_MAPPING = {
                 "screen_display": {
                     "device_class": SwitchDeviceClass.SWITCH,
                     "translation_key": "screen_close",
-                    # Codec expects a numeric screen_display; read live on/off
-                    # state from screen_display_now.
-                    "state_attribute": "screen_display_now",
-                    "rationale": [0, 100],
                 },
                 "prevent_super_cool": {
                     "device_class": SwitchDeviceClass.SWITCH,

--- a/custom_components/midea_auto_cloud/switch.py
+++ b/custom_components/midea_auto_cloud/switch.py
@@ -52,14 +52,8 @@ class MideaSwitchEntity(MideaEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return if the switch is on."""
-        # Prefer an explicit read-only state attribute; otherwise fall back to
-        # the write attribute / entity_key. This lets a switch report state from
-        # one attribute (e.g. the string on/off ``screen_display_now``) while
-        # writing to another (e.g. the numeric ``screen_display`` the codec
-        # expects).
-        attribute = self._config.get("state_attribute") or self._config.get(
-            "attribute", self._entity_key
-        )
+        # Use attribute from config if available, otherwise fall back to entity_key
+        attribute = self._config.get("attribute", self._entity_key)
         return self._get_status_on_off(attribute)
 
     async def async_turn_on(self):


### PR DESCRIPTION
Reverts sususweet/midea_auto_cloud#238 screen_display_now的值有些是off/on，有些是0,100，设备不同不一样