### PR TITLE
fix: adapt screen_display on/off wire format per device (T0xAC)

### DIFF
--- a/custom_components/midea_auto_cloud/device_mapping/T0xAC.py
+++ b/custom_components/midea_auto_cloud/device_mapping/T0xAC.py
@@ -368,10 +368,6 @@ DEVICE_MAPPING = {
         "calculate": {
             "get": [
                 {
-                    "lvalue": "[screen_display]",
-                    "rvalue": "[screen_display_now]"
-                },
-                {
                     "lvalue": "[real_time_power_value]",
                     "rvalue": "float([real_time_power]) / 10"
                 },
@@ -466,7 +462,11 @@ DEVICE_MAPPING = {
                 },
                 "screen_display": {
                     "device_class": SwitchDeviceClass.SWITCH,
-                    "translation_key": "display_on_off"
+                    "translation_key": "display_on_off",
+                    # Codec expects a numeric screen_display; read live on/off
+                    # state from screen_display_now.
+                    "state_attribute": "screen_display_now",
+                    "rationale": [0, 100],
                 },
                 "prevent_straight_wind": {
                     "device_class": SwitchDeviceClass.SWITCH,
@@ -528,12 +528,7 @@ DEVICE_MAPPING = {
         ],
         "centralized": ["buzzer"],
         "calculate":{
-            "get": [
-                {
-                    "lvalue": "[screen_display]",
-                    "rvalue": "[screen_display_now]"
-                },
-            ],
+            "get": [],
             "set": []
         },
         "entities": {
@@ -609,7 +604,11 @@ DEVICE_MAPPING = {
                 },
                 "screen_display": {
                     "device_class": SwitchDeviceClass.SWITCH,
-                    "translation_key": "display_on_off"
+                    "translation_key": "display_on_off",
+                    # Codec expects a numeric screen_display; read live on/off
+                    # state from screen_display_now.
+                    "state_attribute": "screen_display_now",
+                    "rationale": [0, 100],
                 },
                 "prevent_straight_wind": {
                     "device_class": SwitchDeviceClass.SWITCH,
@@ -2247,12 +2246,7 @@ DEVICE_MAPPING = {
                     {"query_type": "wind_swing_ud_angle"}, {"query_type": "wind_swing_lr_angle"}],
         "centralized": ["buzzer"],
         "calculate":{
-            "get": [
-                {
-                    "lvalue": "[screen_display]",
-                    "rvalue": "[screen_display_now]"
-                },
-            ],
+            "get": [],
             "set": []
         },
         "entities": {
@@ -2330,6 +2324,10 @@ DEVICE_MAPPING = {
                 "screen_display": {
                     "device_class": SwitchDeviceClass.SWITCH,
                     "translation_key": "screen_close",
+                    # Codec expects a numeric screen_display; read live on/off
+                    # state from screen_display_now.
+                    "state_attribute": "screen_display_now",
+                    "rationale": [0, 100],
                 },
                 "prevent_straight_wind": {
                     "device_class": SwitchDeviceClass.SWITCH,
@@ -2369,12 +2367,7 @@ DEVICE_MAPPING = {
                     {"query_type": "wind_swing_ud_angle"}, {"query_type": "wind_swing_lr_angle"}],
         "centralized": ["buzzer"],
         "calculate":{
-            "get": [
-                {
-                    "lvalue": "[screen_display]",
-                    "rvalue": "[screen_display_now]"
-                },
-            ],
+            "get": [],
             "set": []
         },
         "entities": {
@@ -2460,6 +2453,10 @@ DEVICE_MAPPING = {
                 "screen_display": {
                     "device_class": SwitchDeviceClass.SWITCH,
                     "translation_key": "screen_close",
+                    # Codec expects a numeric screen_display; read live on/off
+                    # state from screen_display_now.
+                    "state_attribute": "screen_display_now",
+                    "rationale": [0, 100],
                 },
                 "prevent_super_cool": {
                     "device_class": SwitchDeviceClass.SWITCH,

--- a/custom_components/midea_auto_cloud/device_mapping/T0xAC.py
+++ b/custom_components/midea_auto_cloud/device_mapping/T0xAC.py
@@ -463,8 +463,10 @@ DEVICE_MAPPING = {
                 "screen_display": {
                     "device_class": SwitchDeviceClass.SWITCH,
                     "translation_key": "display_on_off",
-                    # Codec expects a numeric screen_display; read live on/off
-                    # state from screen_display_now.
+                    # Read state from screen_display_now when reported (string
+                    # or numeric, device dependent). Write numeric 0/100 unless
+                    # the device decodes screen_display as an on/off string, in
+                    # which case the wire format is mirrored.
                     "state_attribute": "screen_display_now",
                     "rationale": [0, 100],
                 },
@@ -605,8 +607,10 @@ DEVICE_MAPPING = {
                 "screen_display": {
                     "device_class": SwitchDeviceClass.SWITCH,
                     "translation_key": "display_on_off",
-                    # Codec expects a numeric screen_display; read live on/off
-                    # state from screen_display_now.
+                    # Read state from screen_display_now when reported (string
+                    # or numeric, device dependent). Write numeric 0/100 unless
+                    # the device decodes screen_display as an on/off string, in
+                    # which case the wire format is mirrored.
                     "state_attribute": "screen_display_now",
                     "rationale": [0, 100],
                 },
@@ -2324,8 +2328,10 @@ DEVICE_MAPPING = {
                 "screen_display": {
                     "device_class": SwitchDeviceClass.SWITCH,
                     "translation_key": "screen_close",
-                    # Codec expects a numeric screen_display; read live on/off
-                    # state from screen_display_now.
+                    # Read state from screen_display_now when reported (string
+                    # or numeric, device dependent). Write numeric 0/100 unless
+                    # the device decodes screen_display as an on/off string, in
+                    # which case the wire format is mirrored.
                     "state_attribute": "screen_display_now",
                     "rationale": [0, 100],
                 },
@@ -2453,8 +2459,10 @@ DEVICE_MAPPING = {
                 "screen_display": {
                     "device_class": SwitchDeviceClass.SWITCH,
                     "translation_key": "screen_close",
-                    # Codec expects a numeric screen_display; read live on/off
-                    # state from screen_display_now.
+                    # Read state from screen_display_now when reported (string
+                    # or numeric, device dependent). Write numeric 0/100 unless
+                    # the device decodes screen_display as an on/off string, in
+                    # which case the wire format is mirrored.
                     "state_attribute": "screen_display_now",
                     "rationale": [0, 100],
                 },

--- a/custom_components/midea_auto_cloud/midea_entity.py
+++ b/custom_components/midea_auto_cloud/midea_entity.py
@@ -23,6 +23,7 @@ class Rationale(IntEnum):
     LESS = 2
 
 _YES_NO_VALUES = frozenset({"yes", "no"})
+_ON_OFF_VALUES = frozenset({"on", "off"})
 
 
 class MideaEntity(CoordinatorEntity[MideaDataUpdateCoordinator], Entity):
@@ -234,22 +235,31 @@ class MideaEntity(CoordinatorEntity[MideaDataUpdateCoordinator], Entity):
         """Normalize common on/off wire formats to bool."""
         if isinstance(value, bool):
             return value
-        if isinstance(value, (int, float)) and int(value) in (0, 1):
-            return bool(int(value))
+        if isinstance(value, (int, float)):
+            # Devices report levels like 0/100 for off/on; nonzero means on.
+            return value != 0
         if isinstance(value, str):
             normalized = value.lower()
-            if normalized in ("yes", "on", "true", "1"):
+            if normalized in ("yes", "on", "true"):
                 return True
-            if normalized in ("no", "off", "false", "0"):
+            if normalized in ("no", "off", "false"):
                 return False
+            try:
+                return float(normalized) != 0
+            except ValueError:
+                return None
         return None
 
     def _on_off_wire_value(self, turn_on: bool, attribute_key: str | None = None) -> Any:
         """Return the on/off value to send, matching the device's wire format."""
         if attribute_key:
             current = self._get_nested_value(attribute_key)
-            if isinstance(current, str) and current.lower() in _YES_NO_VALUES:
-                return "yes" if turn_on else "no"
+            if isinstance(current, str):
+                normalized = current.lower()
+                if normalized in _YES_NO_VALUES:
+                    return "yes" if turn_on else "no"
+                if normalized in _ON_OFF_VALUES:
+                    return "on" if turn_on else "off"
         return self._rationale[int(turn_on)]
 
     def _get_status_on_off(self, attribute_key: str | None) -> bool:

--- a/custom_components/midea_auto_cloud/switch.py
+++ b/custom_components/midea_auto_cloud/switch.py
@@ -52,14 +52,13 @@ class MideaSwitchEntity(MideaEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return if the switch is on."""
-        # Prefer an explicit read-only state attribute; otherwise fall back to
-        # the write attribute / entity_key. This lets a switch report state from
-        # one attribute (e.g. the string on/off ``screen_display_now``) while
-        # writing to another (e.g. the numeric ``screen_display`` the codec
-        # expects).
-        attribute = self._config.get("state_attribute") or self._config.get(
-            "attribute", self._entity_key
-        )
+        # Prefer an explicit read-only state attribute (e.g.
+        # ``screen_display_now``) when the device reports it; some devices
+        # never report it, so fall back to the write attribute / entity_key.
+        attribute = self._config.get("attribute", self._entity_key)
+        state_attribute = self._config.get("state_attribute")
+        if state_attribute and self._get_nested_value(state_attribute) is not None:
+            attribute = state_attribute
         return self._get_status_on_off(attribute)
 
     async def async_turn_on(self):

--- a/custom_components/midea_auto_cloud/switch.py
+++ b/custom_components/midea_auto_cloud/switch.py
@@ -52,8 +52,14 @@ class MideaSwitchEntity(MideaEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return if the switch is on."""
-        # Use attribute from config if available, otherwise fall back to entity_key
-        attribute = self._config.get("attribute", self._entity_key)
+        # Prefer an explicit read-only state attribute; otherwise fall back to
+        # the write attribute / entity_key. This lets a switch report state from
+        # one attribute (e.g. the string on/off ``screen_display_now``) while
+        # writing to another (e.g. the numeric ``screen_display`` the codec
+        # expects).
+        attribute = self._config.get("state_attribute") or self._config.get(
+            "attribute", self._entity_key
+        )
         return self._get_status_on_off(attribute)
 
     async def async_turn_on(self):


### PR DESCRIPTION
# fix: adapt screen_display on/off wire format per device (T0xAC)

重新提交 #238,按 #242 的反馈完善:`screen_display_now` 的取值因设备而异,本 PR 对所有已知形态做了自适应兼容。

## 问题回顾

壁挂空调「屏显」开关 `switch.turn_off` 报 `Failed to send command`。
根因:`calculate.get` 规则 `screen_display = screen_display_now` 把数值 `screen_display`(如 `100`)覆盖成字符串 `"on"/"off"`;开关用默认 `["off","on"]` rationale,于是下发 `screen_display: "off"`。设备 Lua 编解码器把该字段当数值做 crc8 运算,遇到字符串直接崩溃:

```
bit.lua:231: attempt to perform arithmetic on local 'b' (a string value)
  in function 'crc8_854'
```

本地编解码器和云端都会拒绝该命令(云端返回 code 1014 "lua analysis exception")。

## #242 指出的问题

#238 一律写数值 `0/100`,但实测各设备形态不同:

| 设备形态 | `screen_display`(解码值) | `screen_display_now` |
| --- | --- | --- |
| A(我的设备) | `100` / `0`(数值) | `"on"` / `"off"` |
| B | 数值 | `0` / `100`(或字符串 `"100"`) |
| C | `"on"` / `"off"`(字符串) | `"on"` / `"off"` |
| D(#195) | 数值 | 完全不上报 |

关键结论:**不能用 `screen_display_now` 的格式推断写入格式**——形态 A 就是反例(`screen_display_now` 是字符串,但编解码器写入要求数值)。可靠的信号是设备自己解码出的 **`screen_display` 本身的格式**:同一个 Lua codec 对同一字段的 decode/encode 格式是一致的。

## 改动

1. **写入自适应**(`midea_entity.py::_on_off_wire_value`):若设备解码出的 `screen_display` 是 `"on"/"off"` 字符串,则镜像回字符串(即形态 C 原来的可用行为);数值设备按 `rationale [0, 100]` 发数值。沿用了该函数已有的 yes/no 镜像先例。
2. **读取兼容**(`midea_entity.py::_coerce_on_off`):数值按「非零即开」处理,并识别 `"100"` 这类数值字符串——覆盖 `"on"/"off"`、`0/100`、`"100"/"0"` 三种上报形态。
3. **读取回落**(`switch.py::is_on`):新增可选 `state_attribute`;仅当设备实际上报 `screen_display_now` 时才从它读状态,否则回落读写入属性本身——修复形态 D(#195)开关永远显示 off 的问题。向后兼容,未配置 `state_attribute` 的开关行为不变。
4. **`T0xAC.py`**:同 #238,删除 4 个块里污染 `screen_display` 的 calc 规则;开关配置 `state_attribute: screen_display_now` + `rationale: [0, 100]`。

## 验证

- 用日志里真实崩溃的 payload 针对真实设备 Lua 编解码器回放:字符串复现 crc8 崩溃,数值生成合法指令 `turn_off → …0024ac84`(0x00)、`turn_on → …6424cdff`(0x64 = 100)。
- 桩测试覆盖 A/B/C/D 四种形态的读+写共 19 项检查全部通过,并回归确认默认 `["off","on"]`、数值 `[1, 2]` rationale 及 yes/no 镜像等既有行为不变。
- 形态 A(本人设备)已实际使用数天正常。

## 请求协助确认

对形态 B(上报 `0/100` 的设备),写入数值是基于 decode/encode 格式一致的推断;如有此类设备的用户,烦请实测确认开关可控。

Fixes #195,回应 #242 的 revert。
