### PR TITLE
feat(device_mapping): add T0x17 laundry rack M1100014 (D35W MAX) mapping

### DIFF
--- a/custom_components/midea_auto_cloud/device_mapping/T0x17.py
+++ b/custom_components/midea_auto_cloud/device_mapping/T0x17.py
@@ -1,3 +1,5 @@
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.components.switch import SwitchDeviceClass
 from homeassistant.const import Platform, PERCENTAGE, UnitOfTime
 
@@ -83,6 +85,102 @@ DEVICE_MAPPING = {
                     "device_class": SwitchDeviceClass.SWITCH,
                 }
             }
+        }
+    },
+    # Midea D35W MAX smart laundry rack (sn8 M1100014), verified against
+    # lua protocol T_0000_17_M1100014_2025121306.lua and a real device.
+    "M1100014": {
+        "rationale": ["off", "on"],
+        "queries": [{}],
+        "centralized": [],
+        "entities": {
+            Platform.COVER: {
+                "updown": {
+                    "open_value": "up",
+                    "close_value": "down",
+                    "stop_value": "pause",
+                }
+            },
+            Platform.NUMBER: {
+                "custom_height": {
+                    "min": 0,
+                    "max": 100,
+                    "step": 10,
+                },
+                "custom_timing": {
+                    "min": 0,
+                    "max": 180,
+                    "step": 5,
+                    "unit_of_measurement": UnitOfTime.MINUTES,
+                },
+                "timing_light_off": {
+                    "min": 0,
+                    "max": 1440,
+                    "step": 1,
+                    "unit_of_measurement": UnitOfTime.MINUTES,
+                },
+                "voice_set": {
+                    "min": 0,
+                    "max": 100,
+                    "step": 1,
+                },
+            },
+            Platform.LIGHT: {
+                "common_light": {
+                    "power": "light",
+                    "brightness": {"light_brightness": [20, 100]}
+                }
+            },
+            Platform.SWITCH: {
+                "laundry": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                },
+                "offline_voice_function": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                },
+                "set_light_off": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                },
+                "mic_switch": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                },
+                "horn_switch": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                },
+                "wakeup_free_switch": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                },
+                "continuous_dialogue_switch": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                },
+                "remote_control_broadcast_switch": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                },
+                "lift_up_switch": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                },
+                "wifi_light_switch": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                },
+            },
+            Platform.BINARY_SENSOR: {
+                "body_induction": {
+                    "device_class": BinarySensorDeviceClass.MOTION,
+                },
+            },
+            Platform.SENSOR: {
+                "current_height": {
+                    "state_class": SensorStateClass.MEASUREMENT,
+                    "unit_of_measurement": "cm",
+                },
+                "location_status": {
+                    "device_class": SensorDeviceClass.ENUM,
+                    "options": ["normal", "upper_limit", "lower_limit"],
+                },
+                "error_code": {
+                    "state_class": SensorStateClass.MEASUREMENT,
+                },
+            },
         }
     }
 }

--- a/custom_components/midea_auto_cloud/translations/en.json
+++ b/custom_components/midea_auto_cloud/translations/en.json
@@ -387,6 +387,9 @@
       },
       "water_box": {
         "name": "Water Box"
+      },
+      "body_induction": {
+        "name": "Human Detection"
       }
     },
     "climate": {
@@ -2966,11 +2969,20 @@
       },
       "keep_fresh_status": {
         "name": "Keep Fresh Status"
+      },
+      "current_height": {
+        "name": "Drop Height"
+      },
+      "location_status": {
+        "name": "Position Status"
       }
     },
     "light": {
       "light": {
         "name": "Light"
+      },
+      "common_light": {
+        "name": "Ceiling Light"
       }
     },
     "lock": {
@@ -3173,6 +3185,15 @@
       },
       "smell_time": {
         "name": "Deodorize Time"
+      },
+      "custom_height": {
+        "name": "Drying Height"
+      },
+      "timing_light_off": {
+        "name": "Light-off Delay"
+      },
+      "voice_set": {
+        "name": "Voice Volume"
       }
     },
     "fan": {
@@ -4417,6 +4438,30 @@
       },
       "flash_dry": {
         "name": "Flash Dry"
+      },
+      "set_light_off": {
+        "name": "Light-off Delay Switch"
+      },
+      "mic_switch": {
+        "name": "Microphone"
+      },
+      "horn_switch": {
+        "name": "Prompt Tone"
+      },
+      "wakeup_free_switch": {
+        "name": "Wake-word Free"
+      },
+      "continuous_dialogue_switch": {
+        "name": "Continuous Dialogue"
+      },
+      "remote_control_broadcast_switch": {
+        "name": "Remote Broadcast"
+      },
+      "lift_up_switch": {
+        "name": "Lift-up to Rise"
+      },
+      "wifi_light_switch": {
+        "name": "Network Indicator"
       }
     },
     "text": {

--- a/custom_components/midea_auto_cloud/translations/zh-Hans.json
+++ b/custom_components/midea_auto_cloud/translations/zh-Hans.json
@@ -407,6 +407,9 @@
       },
       "water_box": {
         "name": "水盒"
+      },
+      "body_induction": {
+        "name": "人体感应"
       }
     },
     "climate": {
@@ -3299,6 +3302,12 @@
       },
       "keep_fresh_status": {
         "name": "保鲜状态"
+      },
+      "current_height": {
+        "name": "下降高度"
+      },
+      "location_status": {
+        "name": "位置状态"
       }
     },
     "light": {
@@ -3316,6 +3325,9 @@
             }
           }
         }
+      },
+      "common_light": {
+        "name": "晾衣灯"
       }
     },
     "lock": {
@@ -3524,6 +3536,15 @@
       },
       "smell_time": {
         "name": "除味时间"
+      },
+      "custom_height": {
+        "name": "晾衣高度"
+      },
+      "timing_light_off": {
+        "name": "延时关灯"
+      },
+      "voice_set": {
+        "name": "语音音量"
       }
     },
     "fan": {
@@ -4768,6 +4789,30 @@
       },
       "flash_dry": {
         "name": "闪烘"
+      },
+      "set_light_off": {
+        "name": "延时关灯功能"
+      },
+      "mic_switch": {
+        "name": "麦克风"
+      },
+      "horn_switch": {
+        "name": "提示音"
+      },
+      "wakeup_free_switch": {
+        "name": "免唤醒"
+      },
+      "continuous_dialogue_switch": {
+        "name": "连续对话"
+      },
+      "remote_control_broadcast_switch": {
+        "name": "遥控播报"
+      },
+      "lift_up_switch": {
+        "name": "轻抬上升"
+      },
+      "wifi_light_switch": {
+        "name": "联网指示灯"
       }
     },
     "text": {


### PR DESCRIPTION
## Summary

Add an sn8-specific mapping for the Midea D35W MAX smart laundry rack (T0x17, sn8 `M1100014`, subtype `0`), derived from the device lua protocol (`T_0000_17_M1100014_2025121306.lua`) and verified on real hardware. Previously this device fell through to `default_laundry_rack` and only exposed 6 entities.

## Entities added (20 total, 6 platforms)

- **cover**: updown
- **light**: common_light (with brightness)
- **number**: custom_height, custom_timing, **timing_light_off** (new, light-off delay 0-1440 min), **voice_set** (new, voice volume 0-100)
- **switch**: laundry, offline_voice_function, plus 8 new voice/feature switches: **set_light_off, mic_switch, horn_switch, wakeup_free_switch, continuous_dialogue_switch, remote_control_broadcast_switch, lift_up_switch, wifi_light_switch**
- **binary_sensor**: **body_induction** (motion)
- **sensor**: **current_height** (drop height in cm), **location_status** (ENUM: normal/upper_limit/lower_limit), error_code

## Notes

- D35W MAX has no drying/sterilization hardware, so drying/PTC/UV attributes coming from the shared category lua are intentionally not mapped (they would stay 0 forever).
- `current_height` semantics confirmed on real device: 0 = fully retracted (upper limit), 110 = fully extended (1100 mm max drop) — so it is named "Drop Height" with `cm` unit.
- All 8 new switches are writable per the lua control section; they were exercised on the real device.
- Added missing `en` / `zh-Hans` translations for the new keys, and also for `light.common_light` and `number.custom_height`, which were previously untranslated for **all** laundry racks (they fell back to raw attribute names).
- Purely additive change: `default_laundry_rack` and existing sn8 entries are untouched (verified with `git diff` against master).

## Testing

- Deployed on a live HA instance running integration v0.4.18; all 20 entities created, cover/light/switches control the device, drop-height and position sensors report real values.
- Mapping module import and sn8 match validated against the runtime device info (`type=23 sn8='M1100014' subtype='0' category='laundry-rack'`).
