### PR TITLE
feat(device_mapping): add T0x26 bath heater M0100064 mapping and translations

### DIFF
--- a/custom_components/midea_auto_cloud/device_mapping/T0x26.py
+++ b/custom_components/midea_auto_cloud/device_mapping/T0x26.py
@@ -495,11 +495,6 @@ DEVICE_MAPPING = {
                 }
             },
             Platform.NUMBER: {
-                "smelly_threshold": {
-                    "min": 0,
-                    "max": 9,
-                    "step": 1,
-                },
                 "bath_temperature": {
                     "min": 30,
                     "max": 42,
@@ -555,6 +550,14 @@ DEVICE_MAPPING = {
                         "night_light": {"light_mode": "night_light"},
                         "main_light": {"light_mode": "main_light"}
                     }
+                },
+                "smelly_threshold": {
+                    "options": {
+                        "high": {"smelly_threshold": 1},
+                        "medium": {"smelly_threshold": 2},
+                        "low": {"smelly_threshold": 3}
+                    },
+                    "ignore_values": [255, "ff"]
                 }
             },
             Platform.SENSOR: {

--- a/custom_components/midea_auto_cloud/device_mapping/T0x26.py
+++ b/custom_components/midea_auto_cloud/device_mapping/T0x26.py
@@ -396,5 +396,218 @@ DEVICE_MAPPING = {
                 }
             }
         }
+    },
+    "M0100064": {
+        "rationale": ["off", "on"],
+        "queries": [{}],
+        "centralized": [],
+        "entities": {
+            Platform.CLIMATE: {
+                "bath_heater": {
+                    "translation_key": "bath_heater",
+                    "power": "mode",
+                    "hvac_modes": {
+                        "off": {"mode": "close_all"}
+                    },
+                    "preset_modes": {
+                        "close": {"mode": "close_all"},
+                        "heating": {"mode": "heating"},
+                        "bath": {"mode": "bath"},
+                        "ventilation": {"mode": "ventilation"},
+                        "drying": {"mode": "drying"},
+                        "blowing": {"mode": "blowing"}
+                    },
+                    "target_temperature": {
+                        "heating": "heating_temperature",
+                        "bath": "bath_temperature"
+                    },
+                    "current_temperature": "current_temperature",
+                    "swing_modes": {
+                        "heating": {
+                            "key": "heating_direction",
+                            "options": {
+                                "60": {"heating_direction": "60"},
+                                "70": {"heating_direction": "70"},
+                                "80": {"heating_direction": "80"},
+                                "90": {"heating_direction": "90"},
+                                "100": {"heating_direction": "100"},
+                                "110": {"heating_direction": "110"},
+                                "120": {"heating_direction": "120"},
+                                "swing": {"heating_direction": "253"}
+                            }
+                        },
+                        "bath": {
+                            "key": "bath_direction",
+                            "options": {
+                                "60": {"bath_direction": "60"},
+                                "70": {"bath_direction": "70"},
+                                "80": {"bath_direction": "80"},
+                                "90": {"bath_direction": "90"},
+                                "100": {"bath_direction": "100"},
+                                "110": {"bath_direction": "110"},
+                                "120": {"bath_direction": "120"},
+                                "swing": {"bath_direction": "253"}
+                            }
+                        },
+                        "ventilation": {
+                            "key": "blowing_direction",
+                            "options": {
+                                "60": {"blowing_direction": "60"},
+                                "70": {"blowing_direction": "70"},
+                                "80": {"blowing_direction": "80"},
+                                "90": {"blowing_direction": "90"},
+                                "100": {"blowing_direction": "100"},
+                                "110": {"blowing_direction": "110"},
+                                "120": {"blowing_direction": "120"},
+                                "swing": {"blowing_direction": "253"}
+                            }
+                        },
+                        "drying": {
+                            "key": "drying_direction",
+                            "options": {
+                                "60": {"drying_direction": "60"},
+                                "70": {"drying_direction": "70"},
+                                "80": {"drying_direction": "80"},
+                                "90": {"drying_direction": "90"},
+                                "100": {"drying_direction": "100"},
+                                "110": {"drying_direction": "110"},
+                                "120": {"drying_direction": "120"},
+                                "swing": {"drying_direction": "253"}
+                            }
+                        }
+                    },
+                    "min_temp": 30,
+                    "max_temp": 42,
+                    "temperature_unit": UnitOfTemperature.CELSIUS,
+                    "precision": PRECISION_WHOLE
+                }
+            },
+            Platform.LIGHT: {
+                "main_light": {
+                    "power": "light_mode",
+                    "brightness": {"main_light_brightness": [10, 100]},
+                    "rationale": ["close_all", "main_light"]
+                },
+                "night_light": {
+                    "power": "light_mode",
+                    "brightness": {"night_light_brightness": [5, 30]},
+                    "rationale": ["close_all", "night_light"]
+                }
+            },
+            Platform.NUMBER: {
+                "smelly_threshold": {
+                    "min": 0,
+                    "max": 9,
+                    "step": 1,
+                },
+                "bath_temperature": {
+                    "min": 30,
+                    "max": 42,
+                    "step": 1,
+                    "unit_of_measurement": UnitOfTemperature.CELSIUS
+                },
+                "heating_temperature": {
+                    "min": 30,
+                    "max": 42,
+                    "step": 1,
+                    "unit_of_measurement": UnitOfTemperature.CELSIUS
+                },
+                "main_light_brightness": {
+                    "min": 10,
+                    "max": 100,
+                    "step": 1,
+                    "unit_of_measurement": PERCENTAGE
+                },
+                "radar_induction_closing_time": {
+                    "min": 1,
+                    "max": 5,
+                    "step": 1,
+                    "unit_of_measurement": UnitOfTime.MINUTES
+                }
+            },
+            Platform.SWITCH: {
+                "anion_enable": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                },
+                "function_led_enable": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                },
+                "digit_led_enable": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                },
+                "delay_enable": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                },
+                "smelly_enable": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                },
+                "radar_induction_enable": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                },
+                "wifi_led_enable": {
+                    "device_class": SwitchDeviceClass.SWITCH,
+                }
+            },
+            Platform.SELECT: {
+                "light_mode": {
+                    "options": {
+                        "close_all": {"light_mode": "close_all"},
+                        "night_light": {"light_mode": "night_light"},
+                        "main_light": {"light_mode": "main_light"}
+                    }
+                }
+            },
+            Platform.SENSOR: {
+                "bath_heating_time": {
+                    "device_class": SensorDeviceClass.DURATION,
+                    "unit_of_measurement": UnitOfTime.MINUTES,
+                    "state_class": SensorStateClass.MEASUREMENT,
+                },
+                "drying_time": {
+                    "device_class": SensorDeviceClass.DURATION,
+                    "unit_of_measurement": UnitOfTime.MINUTES,
+                    "state_class": SensorStateClass.MEASUREMENT,
+                },
+                "delay_time": {
+                    "device_class": SensorDeviceClass.DURATION,
+                    "unit_of_measurement": UnitOfTime.MINUTES,
+                    "state_class": SensorStateClass.MEASUREMENT,
+                },
+                "blowing_speed": {
+                    "state_class": SensorStateClass.MEASUREMENT,
+                },
+                "ventilation_speed": {
+                    "state_class": SensorStateClass.MEASUREMENT,
+                },
+                "smelly_level": {
+                    "state_class": SensorStateClass.MEASUREMENT,
+                },
+                "night_light_brightness": {
+                    "unit_of_measurement": PERCENTAGE,
+                    "state_class": SensorStateClass.MEASUREMENT
+                },
+                "main_light_brightness": {
+                    "unit_of_measurement": PERCENTAGE,
+                    "state_class": SensorStateClass.MEASUREMENT
+                },
+                "current_temperature": {
+                    "device_class": SensorDeviceClass.TEMPERATURE,
+                    "unit_of_measurement": UnitOfTemperature.CELSIUS,
+                    "state_class": SensorStateClass.MEASUREMENT,
+                    "translation_key": "cur_temperature"
+                }
+            },
+            Platform.BINARY_SENSOR: {
+                "smelly_trigger": {
+                    "device_class": BinarySensorDeviceClass.PROBLEM,
+                },
+                "dehumidity_trigger": {
+                    "device_class": BinarySensorDeviceClass.RUNNING,
+                },
+                "current_radar_status": {
+                    "device_class": BinarySensorDeviceClass.OCCUPANCY
+                }
+            }
+        }
     }
 }

--- a/custom_components/midea_auto_cloud/translations/en.json
+++ b/custom_components/midea_auto_cloud/translations/en.json
@@ -706,6 +706,14 @@
       }
     },
     "select": {
+      "smelly_threshold": {
+        "name": "Odor Threshold",
+        "state": {
+          "high": "High",
+          "medium": "Medium",
+          "low": "Low"
+        }
+      },
       "heating_capacity": {
         "name": "Heating Tank",
         "state": {
@@ -3228,9 +3236,6 @@
       },
       "smell_time": {
         "name": "Deodorize Time"
-      },
-      "smelly_threshold": {
-        "name": "Odor Threshold"
       },
       "bath_temperature": {
         "name": "Bath Temperature"

--- a/custom_components/midea_auto_cloud/translations/en.json
+++ b/custom_components/midea_auto_cloud/translations/en.json
@@ -387,6 +387,15 @@
       },
       "water_box": {
         "name": "Water Box"
+      },
+      "smelly_trigger": {
+        "name": "Odor Detected"
+      },
+      "dehumidity_trigger": {
+        "name": "Dehumidifying"
+      },
+      "current_radar_status": {
+        "name": "Radar Occupancy"
       }
     },
     "climate": {
@@ -634,6 +643,40 @@
       },
       "heating": {
         "name": "Heating"
+      },
+      "bath_heater": {
+        "name": null,
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "close": "Off",
+              "heating": "Heating",
+              "bath": "Bath",
+              "ventilation": "Ventilation",
+              "drying": "Drying",
+              "blowing": "Blowing"
+            }
+          },
+          "preset_modes": {
+            "state": {
+              "close": "Off",
+              "heating": "Heating",
+              "bath": "Bath",
+              "ventilation": "Ventilation",
+              "drying": "Drying",
+              "blowing": "Blowing"
+            }
+          },
+          "swing_mode": {
+            "state": {
+              "swing": "Swing",
+              "heating": "Heating",
+              "bath": "Bath",
+              "ventilation": "Ventilation",
+              "drying": "Drying"
+            }
+          }
+        }
       }
     },
     "cover": {
@@ -2966,11 +3009,23 @@
       },
       "keep_fresh_status": {
         "name": "Keep Fresh Status"
+      },
+      "ventilation_speed": {
+        "name": "Ventilation Speed"
+      },
+      "smelly_level": {
+        "name": "Odor Level"
       }
     },
     "light": {
       "light": {
         "name": "Light"
+      },
+      "main_light": {
+        "name": "Ceiling Light"
+      },
+      "night_light": {
+        "name": "Night Light"
       }
     },
     "lock": {
@@ -3173,6 +3228,18 @@
       },
       "smell_time": {
         "name": "Deodorize Time"
+      },
+      "smelly_threshold": {
+        "name": "Odor Threshold"
+      },
+      "bath_temperature": {
+        "name": "Bath Temperature"
+      },
+      "heating_temperature": {
+        "name": "Heating Temperature"
+      },
+      "main_light_brightness": {
+        "name": "Main Light Brightness"
       }
     },
     "fan": {
@@ -4417,6 +4484,12 @@
       },
       "flash_dry": {
         "name": "Flash Dry"
+      },
+      "anion_enable": {
+        "name": "Anion"
+      },
+      "smelly_enable": {
+        "name": "Odor Detection"
       }
     },
     "text": {

--- a/custom_components/midea_auto_cloud/translations/en.json
+++ b/custom_components/midea_auto_cloud/translations/en.json
@@ -645,7 +645,6 @@
         "name": "Heating"
       },
       "bath_heater": {
-        "name": null,
         "state_attributes": {
           "preset_mode": {
             "state": {
@@ -1101,7 +1100,13 @@
         "name": "Gesture"
       },
       "gesture_value": {
-        "name": "Gesture Value"
+        "name": "Gesture Action",
+        "state": {
+          "power_toggle": "Power Toggle",
+          "adjust_speed": "Adjust Speed",
+          "light_toggle": "Light Toggle",
+          "power_and_speed": "Power & Speed"
+        }
       },
       "gesture_sensitivity_value": {
         "name": "Gesture Sensitivity Value"
@@ -1644,7 +1649,14 @@
         }
       },
       "wind_pressure": {
-        "name": "Wind Pressure"
+        "name": "Wind Pressure",
+        "state": {
+          "off": "Off",
+          "low": "Low",
+          "medium": "Medium",
+          "high": "High",
+          "extreme": "Extreme"
+        }
       },
       "hot_style": {
         "name": "Heating Style"

--- a/custom_components/midea_auto_cloud/translations/zh-Hans.json
+++ b/custom_components/midea_auto_cloud/translations/zh-Hans.json
@@ -750,6 +750,14 @@
       }
     },
     "select": {
+      "smelly_threshold": {
+        "name": "异味检测阈值",
+        "state": {
+          "high": "高",
+          "medium": "中",
+          "low": "低"
+        }
+      },
       "heating_capacity": {
         "name": "加热胆量",
         "state": {
@@ -3579,9 +3587,6 @@
       },
       "smell_time": {
         "name": "除味时间"
-      },
-      "smelly_threshold": {
-        "name": "异味检测阈值"
       }
     },
     "fan": {

--- a/custom_components/midea_auto_cloud/translations/zh-Hans.json
+++ b/custom_components/midea_auto_cloud/translations/zh-Hans.json
@@ -679,7 +679,6 @@
         "name": "采暖"
       },
       "bath_heater": {
-        "name": null,
         "state_attributes": {
           "preset_mode": {
             "state": {
@@ -1271,7 +1270,13 @@
         }
       },
       "gesture_value": {
-        "name": "手势操作"
+        "name": "手势操作",
+        "state": {
+          "power_toggle": "开关机",
+          "adjust_speed": "调风速",
+          "light_toggle": "开关灯",
+          "power_and_speed": "开关机并调风速"
+        }
       },
       "gesture_sensitivity_value": {
         "name": "手势灵敏度",
@@ -1919,7 +1924,14 @@
         }
       },
       "wind_pressure": {
-        "name": "风压"
+        "name": "风压",
+        "state": {
+          "off": "关闭",
+          "low": "低速",
+          "medium": "中速",
+          "high": "高速",
+          "extreme": "强劲"
+        }
       },
       "hot_style": {
         "name": "供热方式"

--- a/custom_components/midea_auto_cloud/translations/zh-Hans.json
+++ b/custom_components/midea_auto_cloud/translations/zh-Hans.json
@@ -407,6 +407,15 @@
       },
       "water_box": {
         "name": "水盒"
+      },
+      "smelly_trigger": {
+        "name": "异味超标"
+      },
+      "dehumidity_trigger": {
+        "name": "除湿运行中"
+      },
+      "current_radar_status": {
+        "name": "雷达感应"
       }
     },
     "climate": {
@@ -668,6 +677,40 @@
       },
       "heating": {
         "name": "采暖"
+      },
+      "bath_heater": {
+        "name": null,
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "close": "关闭",
+              "heating": "制热",
+              "bath": "沐浴",
+              "ventilation": "换气",
+              "drying": "烘干",
+              "blowing": "吹风"
+            }
+          },
+          "preset_modes": {
+            "state": {
+              "close": "关闭",
+              "heating": "制热",
+              "bath": "沐浴",
+              "ventilation": "换气",
+              "drying": "烘干",
+              "blowing": "吹风"
+            }
+          },
+          "swing_mode": {
+            "state": {
+              "swing": "摆风",
+              "heating": "制热",
+              "bath": "沐浴",
+              "ventilation": "换气",
+              "drying": "烘干"
+            }
+          }
+        }
       }
     },
     "cover": {
@@ -3299,6 +3342,12 @@
       },
       "keep_fresh_status": {
         "name": "保鲜状态"
+      },
+      "ventilation_speed": {
+        "name": "换气风速"
+      },
+      "smelly_level": {
+        "name": "异味等级"
       }
     },
     "light": {
@@ -3316,6 +3365,12 @@
             }
           }
         }
+      },
+      "main_light": {
+        "name": "浴霸照明灯"
+      },
+      "night_light": {
+        "name": "起夜灯"
       }
     },
     "lock": {
@@ -3524,6 +3579,9 @@
       },
       "smell_time": {
         "name": "除味时间"
+      },
+      "smelly_threshold": {
+        "name": "异味检测阈值"
       }
     },
     "fan": {
@@ -4768,6 +4826,12 @@
       },
       "flash_dry": {
         "name": "闪烘"
+      },
+      "anion_enable": {
+        "name": "负离子"
+      },
+      "smelly_enable": {
+        "name": "异味检测"
       }
     },
     "text": {


### PR DESCRIPTION
## Summary

Add an sn8-specific mapping for the Midea bath heater (T0x26, sn8 `M0100064`, model MV-DZBPX28-F5), derived from the device lua protocol and verified on real hardware. Previously this device fell through to `default_bath_heater`.

## Entities (28 total, 7 platforms)

- **switch**: anion_enable, function_led_enable, digit_led_enable, delay_enable, smelly_enable, radar_induction_enable (new)
- **select**: light_mode, **smelly_threshold** (new — the Midea app exposes this as a 3-level dropdown: high=1 / medium=2 / low=3, not a 0-9 slider; 255/0xff ignored as unknown)
- **binary_sensor**: smelly_trigger (PROBLEM), dehumidity_trigger (RUNNING), current_radar_status (OCCUPANCY) (new — read-only per lua; upstream default maps the first two as switches)
- **sensor**: bath_heating_time, drying_time, delay_time (DURATION, min), blowing_speed, ventilation_speed, smelly_level (new)
- plus the full default_bath_heater entity set (climate, lights, numbers)

## Translations

- zh-Hans / en: `bath_heater` climate `preset_mode`/`preset_modes`/`swing_mode` state values (close/heating/bath/ventilation/drying/blowing/swing) were untranslated and fell back to raw keys
- names for all new entities and missing defaults (main_light, night_light, current_radar_status)
- select state translations for smelly_threshold (高/中/低)

## Notes

- `windless_enable` / `auto_dehumidification` are writable in lua but never reported by this hardware — intentionally not mapped
- purely additive: `default_bath_heater`, `default`, `M0100040` and other sn8 entries are untouched (+350/-0 lines)
- verified on real hardware: all 28 entities state-report correctly; smelly_threshold select round-trips (high/medium/low) confirmed in production

## Follow-up commits

- **a56c515** — `smelly_threshold` converted from a 0-9 number (slider) to a **select** (high=1 / medium=2 / low=3), matching the Midea app's 3-level dropdown; zh-Hans/en state translations added; 255/0xff ignored as unknown. Verified on real hardware.
- **c9a9aac** — removed a `"name": null` in `entity.climate.bath_heater` that crashed HA's translation loader (`_validate_placeholders` only catches `ValueError`; `string.Formatter().parse(None)` raises `TypeError` and failed the whole integration setup). Also adds zh-Hans/en state translations for the range-hood (T0xB6) `wind_pressure` and `gesture_value` selects, which previously fell back to raw keys.

All changes remain purely additive to `default_*` mappings and other devices' translations (+380/-10 total).